### PR TITLE
Update Dockerfile deploy structure and add migrations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN go mod download
 COPY qrcode ./qrcode
 COPY *.go ./
 
-RUN CGO_ENABLED=1 go build -ldflags "-w -s" -o /cpubench
+RUN CGO_ENABLED=1 go build -ldflags "-w -s" -o /qrcode-api
 
 # hadolint ignore=DL3007
 FROM gcr.io/distroless/base-debian13:latest AS deploy
@@ -15,8 +15,8 @@ FROM gcr.io/distroless/base-debian13:latest AS deploy
 WORKDIR /opt
 
 # hadolint ignore=DL3045
-COPY --from=build /cpubench /opt/
+COPY --from=build /qrcode-api /opt/
 COPY migrations /opt/migrations
 
 EXPOSE 3000
-ENTRYPOINT ["/opt/cpubench"]
+ENTRYPOINT ["/opt/qrcode-api"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,16 @@ RUN go mod download
 COPY qrcode ./qrcode
 COPY *.go ./
 
-RUN CGO_ENABLED=1 go build -ldflags "-w -s" -o /qrcode-api
+RUN CGO_ENABLED=1 go build -ldflags "-w -s" -o /cpubench
 
 # hadolint ignore=DL3007
 FROM gcr.io/distroless/base-debian13:latest AS deploy
 
+WORKDIR /opt
+
 # hadolint ignore=DL3045
-COPY --from=build /qrcode-api /
+COPY --from=build /cpubench /opt/
+COPY migrations /opt/migrations
 
 EXPOSE 3000
-ENTRYPOINT ["/qrcode-api"]
+ENTRYPOINT ["/opt/cpubench"]


### PR DESCRIPTION
The Dockerfile has been updated to meet the new deployment requirements:
1. The binary is now built with the name `cpubench`.
2. The deployment stage now uses `/opt` as its working directory.
3. The `cpubench` binary and the `migrations` directory are copied into `/opt`.
4. The `ENTRYPOINT` has been updated to execute `/opt/cpubench`.

---
*PR created automatically by Jules for task [13534539450411197838](https://jules.google.com/task/13534539450411197838) started by @kahnwong*